### PR TITLE
fix: Close Settings dialog when clicking outside

### DIFF
--- a/content.js
+++ b/content.js
@@ -15,12 +15,14 @@
         bg: null, wrapper: null,
         title: null, artist: null, artwork: null,
         lyrics: null, input: null, settings: null,
-        btnArea: null, uploadMenu: null, deleteDialog: null
+        btnArea: null, uploadMenu: null, deleteDialog: null,
+        settingsBtn: null
     };
 
     let hideTimer = null;
     let uploadMenuGlobalSetup = false;
     let deleteDialogGlobalSetup = false;
+    let settingsOutsideClickSetup = false;
 
     const handleInteraction = () => {
         if (!ui.btnArea) return;
@@ -471,6 +473,17 @@
                 ui.settings.classList.remove('active');
             };
         }
+
+        if (!settingsOutsideClickSetup) {
+            settingsOutsideClickSetup = true;
+            document.addEventListener('click', (ev) => {
+                if (!ui.settings) return;
+                if (!ui.settings.classList.contains('active')) return;
+                if (ui.settings.contains(ev.target)) return;
+                if (ui.settingsBtn && ui.settingsBtn.contains(ev.target)) return;
+                ui.settings.classList.remove('active');
+            }, true);
+        }
     }
 
     function initLayout() {
@@ -517,6 +530,7 @@
 
             if (b === uploadBtnConfig) setupUploadMenu(btn);
             if (b === trashBtnConfig)  setupDeleteDialog(btn);
+            if (b === settingsBtnConfig) ui.settingsBtn = btn;
         });
 
         ui.input = createEl('input');


### PR DESCRIPTION
Thank you for your Chrome Extension!

## Summary

When the Settings panel is active, close it on clicks outside the panel or the settings gear.  
A reference to the gear button is stored to define the allowlist boundary.

## Before / After

- **Before**: Settings panel remains open unless the gear/close button is clicked.  
- **After**: Outside click closes the panel; interaction inside the panel or on the gear is preserved.

## Scope & Boundary

- The outside-click handler runs **only when Settings is active**.
- Allowlist = **{Settings panel, settings gear button}**.
- Other UI controls (upload, trash, immersion, etc.) are unaffected.
- If additional entry points to open Settings are added later, they must be added to the allowlist.

## Implementation Notes

- Single document-level capture listener; adds/removes `active` via containment checks.
- Mirrors the existing delete-dialog outside-click behavior.
- No CSS or storage changes.

## Verification

- Open Settings → click outside → panel closes.
- Click inside panel → remains open.
- Toggle via gear → works as before.

If anything feels off, just drop a comment on the PR.