### PR TITLE
歌詞のダイナミック追跡（1文字追跡）が機能しない問題の修正

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -137,11 +137,6 @@ body.ytm-custom-layout ytmusic-search-box {
     opacity: 1;
 }
 
-/* API設定×ボタン */
-#ytm-settings-close-btn {
-    /* position等は inline-style で付与済み */
-}
-
 /* 歌詞エリア */
 #my-lyrics-container { width: 500px; height: 65vh; overflow-y: auto; scrollbar-width: none; mask-image: linear-gradient(to bottom, transparent, black 15%, black 85%, transparent); }
 #my-lyrics-container::-webkit-scrollbar { display: none; }
@@ -191,6 +186,24 @@ body.ytm-custom-layout.ytm-has-timestamp .lyric-line.show-translation .lyric-tra
     opacity: 0.95;
     max-height: 4em;
     margin-top: 6px;
+}
+
+/* ★ Apple Music 風：1文字ずつ光る演出 */
+body.ytm-custom-layout .lyric-line .lyric-char {
+    display: inline-block;
+    transition:
+        color 0.12s linear,
+        transform 0.12s linear,
+        text-shadow 0.12s linear,
+        opacity 0.12s linear;
+}
+body.ytm-custom-layout .lyric-line .lyric-char.char-pending {
+    opacity: 0.35;
+}
+body.ytm-custom-layout .lyric-line.active .lyric-char.char-active {
+    opacity: 1;
+    transform: translateY(-1px);
+    text-shadow: 0 0 12px rgba(255,255,255,0.8);
 }
 
 /* プレーヤーバーのスタイル */

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -298,7 +298,7 @@
                     alert('動画IDが取得できませんでした。YouTube Music の再生画面で実行してください。');
                     return;
                 }
-                // DynamicLyrics.json 直接編集
+                // DynamicLyrics.json 直接編集（※ここはブラウザで GitHub を開くだけ。拡張からの直接 fetch は行っていません）
                 const githubUrl = `https://github.com/LRCHub/${vid}/edit/main/README.md`;
                 window.open(githubUrl, '_blank');
             }
@@ -1017,6 +1017,7 @@
                     r.scrollIntoView({ behavior: 'smooth', block: 'center' });
                 }
 
+                // ★ Apple Music っぽく、アクティブ行だけ 1文字ずつハイライトを進める
                 if (dynamicLines && dynamicLines[i] && Array.isArray(dynamicLines[i].chars)) {
                     const charSpans = r.querySelectorAll('.lyric-char');
                     charSpans.forEach(sp => {


### PR DESCRIPTION
・対応曲でも1文字ずつ表示されない問題を修正しました

修正内容
 - 消えてしまったcssを復元しました。
 - その他ちょっとシステムの変更

CSSが無かったことによって裏でしか処理されず、見た目に反映が無かったようです。

プルリクが通ったらお楽しみください！
対応曲の例
https://music.youtube.com/watch?v=qhmrt3ZNgcs&list=RDAMVMqhmrt3ZNgcs
https://music.youtube.com/watch?v=Mtfkq7doqWw&list=OLAK5uy_ned61ggF_96UkOKn1G77I2y-nTZ3hR1uo
https://music.youtube.com/watch?v=TbOLDRuKsgA
