### PR TITLE
fix: 歌詞の一番上部分を中央に表示するようにした

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -170,7 +170,14 @@ body.ytm-custom-layout ytmusic-search-box {
 }
 
 /* 歌詞エリア */
-#my-lyrics-container { width: 500px; height: 65vh; overflow-y: auto; scrollbar-width: none; mask-image: linear-gradient(to bottom, transparent, black 15%, black 85%, transparent); }
+#my-lyrics-container { 
+  width: 500px; 
+  height: 65vh; 
+  overflow-y: auto; 
+  scrollbar-width: none; 
+  mask-image: linear-gradient(to bottom, transparent, black 15%, black 85%, transparent);
+  padding-top: 30vh;
+}
 #my-lyrics-container::-webkit-scrollbar { display: none; }
 
 /* ★ 修正ポイント: 


### PR DESCRIPTION
# 概要
<!-- このPRの目的と概要 -->
歌詞の最初部分が上の方の表示になっている部分を中央に表示されるようにした。

# 変更点
<!-- 具体的な変更点や修正箇所を箇条書きでリストアップ -->
- 最初の歌詞の上部分にpaddingを追加。

# ピクチャ
|修正前|修正後|
|:-:|:-:|
|<img width="1918" height="946" alt="image" src="https://github.com/user-attachments/assets/2de074d6-c278-4559-9b95-ecee87e8bfe8" />|<img width="1917" height="946" alt="image" src="https://github.com/user-attachments/assets/00b5d57a-6d03-4f2e-b260-036ae7857bb1" />|


# 関連Issue
<!-- このPRが関連するIssueやタスクをリンクしてください。 -->
- https://discord.com/channels/1443238144987107358/1444227787169988638

# 動作確認
- `Google Chrome バージョン 142.0.7444.176（Official Build） （64 ビット）` on Windows
- `Arc Browser Based on Chromium version 142.0.7444.176 (Official Build) （64 ビット）` on Windows