### PR TITLE
fix: プレイヤーバーからプレイヤーページを閉じるボタンがはみ出ている問題を修正

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -273,7 +273,7 @@ body.ytm-custom-layout .lyric-line.active .lyric-char.char-active {
 body.ytm-custom-layout ytmusic-player-bar {
   position: fixed !important; 
   bottom: 40px !important; left: 50% !important; transform: translateX(-50%) !important;
-  width: 95% !important; max-width: 900px !important; 
+  width: 95% !important; max-width: 975px !important; 
   height: 80px !important; border-radius: 40px !important;
   background: rgba(20,20,20,0.6) !important; backdrop-filter: blur(60px) saturate(180%) !important;
   border: 1px solid rgba(255,255,255,0.15) !important; 


### PR DESCRIPTION
# 概要
<!-- このPRの目的と概要 -->
プレイヤーバーから「プレイヤーページを閉じる」ボタンがはみ出ている問題を修正した。

# 変更点
<!-- 具体的な変更点や修正箇所を箇条書きでリストアップ -->
- プレイヤーバーのmax-weightを975pxに上げた。

# ピクチャ
|修正前|修正後|
|:-:|:-:|
|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/16cdebd7-8e7d-41f5-9df8-3f39ba165a94" />|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/960c37a0-31a5-447d-b654-2b332e173ee4" />|


# 関連Issue
<!-- このPRが関連するIssueやタスクをリンクしてください。 -->
- https://discord.com/channels/1443238144987107358/1444305636996419776

# 動作確認
- `Google Chrome バージョン 142.0.7444.176（Official Build） （64 ビット）` on Windows
- `Arc Browser Based on Chromium version 142.0.7444.176 (Official Build) （64 ビット）` on Windows