### PR TITLE
fix: 左寄せになっていた部分を中央揃えにした

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -104,9 +104,9 @@ body.ytm-custom-layout ytmusic-search-box {
 
 #ytm-btn-area {
     display: flex;
-		gap: 10px;
-		justify-content: center;
-		margin-top: 10px;
+    gap: 10px;
+    justify-content: center;
+    margin-top: 10px;
     transition: opacity 0.5s ease, visibility 0.5s ease;
     opacity: 1;
     visibility: visible;


### PR DESCRIPTION
# 概要
<!-- このPRの目的と概要 -->
ボタンの揃えが左寄せになっていた部分を中央揃えにした。

# 変更点
<!-- 具体的な変更点や修正箇所を箇条書きでリストアップ -->
- justify-content: centerを追加。

# ピクチャ
|修正前|修正後|
|:-:|:-:|
|<img width="431" height="603" alt="image" src="https://github.com/user-attachments/assets/a2c2c3a8-9eda-46b7-8af2-8e06f930026f" />|<img width="421" height="596" alt="image" src="https://github.com/user-attachments/assets/7a489acb-8b9c-441d-a252-57c85f9ab687" />|


# 関連Issue
<!-- このPRが関連するIssueやタスクをリンクしてください。 -->

# 動作確認
- `Google Chrome バージョン 142.0.7444.176（Official Build） （64 ビット）` on Windows
- `Arc Browser Based on Chromium version 142.0.7444.176 (Official Build) （64 ビット）` on Windows