### PR TITLE
立て画面レイアウトの修正

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -991,6 +991,19 @@ body:not(.ytm-custom-layout) ytmusic-player-bar .right-controls .toggle-player-p
     left: 50% !important;
     transform: translateX(-50%) !important;
   }
+
+  body.ytm-custom-layout .ytm-upload-menu {
+    top: 52px;
+    bottom: auto;
+    right: 0;
+    transform-origin: top right;
+  }
+
+  body.ytm-custom-layout .ytm-confirm-dialog {
+    top: 52px;
+    bottom: auto;
+    right: 56px;
+    transform-origin: top right;
 }
 
 /* フォールバック通知トースト */


### PR DESCRIPTION
立て画面の時にLyriceメニューが隠れていたので下側に展開するようにしました
<img width="650" height="935" alt="image" src="https://github.com/user-attachments/assets/da35da80-6fec-4537-8815-eb2e52606d06" />
