### PR TITLE
fix: prevent race condition in replay recording

### DIFF
--- a/src/js/module/replay-manager.js
+++ b/src/js/module/replay-manager.js
@@ -2,6 +2,7 @@
     HISTORY_KEY: 'ytm_local_history',
     currentVideoId: null,
     hasRecordedCurrent: false,
+    isRecording: false,
     currentPlayTime: 0,
     lastSaveTime: 0,
 
@@ -86,6 +87,7 @@
       if (vid !== this.currentVideoId) {
         this.currentVideoId = vid;
         this.hasRecordedCurrent = false;
+        this.isRecording = false;
         this.currentPlayTime = 0;
         this.lastSaveTime = 0;
         this.currentLyricLines = 0;
@@ -98,12 +100,22 @@
         const isPlayed = this.currentPlayTime > 30 || (video.duration > 10 && this.currentPlayTime / video.duration > 0.4);
 
         if (isPlayed) {
-          if (!this.hasRecordedCurrent) {
-            await this.recordNewPlay();
-            this.hasRecordedCurrent = true;
-          } else if (this.currentPlayTime - this.lastSaveTime >= 5) {
-            await this.updateDuration();
-            this.lastSaveTime = this.currentPlayTime;
+          if (!this.hasRecordedCurrent && !this.isRecording) {
+            this.isRecording = true;
+            try {
+              await this.recordNewPlay();
+              this.hasRecordedCurrent = true;
+            } finally {
+              this.isRecording = false;
+            }
+          } else if (this.currentPlayTime - this.lastSaveTime >= 5 && !this.isRecording) {
+            this.isRecording = true;
+            try {
+              await this.updateDuration();
+              this.lastSaveTime = this.currentPlayTime;
+            } finally {
+              this.isRecording = false;
+            }
           }
         }
       }
@@ -432,5 +444,3 @@
       setInterval(() => this.check(), 1000);
     }
   };
-
-


### PR DESCRIPTION
1. Summary: Added a locking mechanism to `ReplayManager.check` to prevent multiple concurrent calls to `recordNewPlay` and `updateDuration` if the interval fires while an asynchronous recording or update operation is already in progress.
2. Rationale: The `check` function, which is called every 1000ms by an interval, was susceptible to re-entry because `this.hasRecordedCurrent` was only set to `true` after the asynchronous `await this.recordNewPlay()` call completed. This allowed a second `check` invocation to trigger a redundant recording process. Similarly, `updateDuration` was vulnerable to concurrent storage operations.
3. Technical impact: Prevents redundant history entries and race conditions during play-time recording, ensuring data integrity for the playback history. Added `isRecording` state to the `ReplayManager` object and protected critical sections with `try-finally` blocks to ensure lock release.